### PR TITLE
Proposed changes

### DIFF
--- a/ports/directx-dxc/directx-dxc-config.cmake.in
+++ b/ports/directx-dxc/directx-dxc-config.cmake.in
@@ -11,6 +11,8 @@ set_target_properties(Microsoft::DirectXShaderCompiler PROPERTIES
    IMPORTED_SONAME                      "@lib_name@"
    INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
    INTERFACE_LINK_LIBRARIES             "Microsoft::DXIL"
+   MAP_IMPORTED_CONFIG_MINSIZEREL       ""
+   MAP_IMPORTED_CONFIG_RELWITHDEBINFO   ""   
    IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 
 add_library(Microsoft::DXIL SHARED IMPORTED)
@@ -19,6 +21,8 @@ set_target_properties(Microsoft::DXIL PROPERTIES
    IMPORTED_IMPLIB                      "${_dxc_root}/lib/@lib_name@"
    IMPORTED_SONAME                      "@lib_name@"
    INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
+   MAP_IMPORTED_CONFIG_MINSIZEREL       ""
+   MAP_IMPORTED_CONFIG_RELWITHDEBINFO   ""   
    IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 
 unset(_dxc_root)

--- a/ports/directx-dxc/directx-dxc-config.cmake.in
+++ b/ports/directx-dxc/directx-dxc-config.cmake.in
@@ -1,44 +1,24 @@
-
 get_filename_component(_dxc_root "${CMAKE_CURRENT_LIST_DIR}" PATH)
 get_filename_component(_dxc_root "${_dxc_root}" PATH)
 
-set(_dxc_exe "${_dxc_root}/@tool_path@")
-if (EXISTS "${_dxc_exe}")
+set(DIRECTX_DXC_TOOL "${_dxc_root}/@tool_path@" CACHE PATH "Location of the dxc tool")
+mark_as_advanced(DIRECTX_DXC_TOOL)
 
-   add_library(Microsoft::DirectXShaderCompiler SHARED IMPORTED)
-   set_target_properties(Microsoft::DirectXShaderCompiler PROPERTIES
-      IMPORTED_LOCATION_RELEASE            "${_dxc_root}/@dll_dir@/@dll_name_dxc@"
-      IMPORTED_LOCATION_DEBUG              "${_dxc_root}/@dll_dir@/@dll_name_dxc@"
-      IMPORTED_IMPLIB_RELEASE              "${_dxc_root}/lib/@lib_name@"
-      IMPORTED_IMPLIB_DEBUG                "${_dxc_root}/lib/@lib_name@"
-      IMPORTED_SONAME_RELEASE              "@lib_name@"
-      IMPORTED_SONAME_DEBUG                "@lib_name@"
-      INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
-      IMPORTED_CONFIGURATIONS              "Debug;Release"
-      IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
+add_library(Microsoft::DirectXShaderCompiler SHARED IMPORTED)
+set_target_properties(Microsoft::DirectXShaderCompiler PROPERTIES
+   IMPORTED_LOCATION                    "${_dxc_root}/@dll_dir@/@dll_name_dxc@"
+   IMPORTED_IMPLIB                      "${_dxc_root}/lib/@lib_name@"
+   IMPORTED_SONAME                      "@lib_name@"
+   INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
+   INTERFACE_LINK_LIBRARIES             "Microsoft::DXIL"
+   IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 
-   add_library(Microsoft::DXIL SHARED IMPORTED)
-   set_target_properties(Microsoft::DXIL PROPERTIES
-      IMPORTED_LOCATION_RELEASE            "${_dxc_root}/@dll_dir@/@dll_name_dxil@"
-      IMPORTED_LOCATION_DEBUG              "${_dxc_root}/@dll_dir@/@dll_name_dxil@"
-      IMPORTED_IMPLIB_RELEASE              "${_dxc_root}/lib/@lib_name@"
-      IMPORTED_IMPLIB_DEBUG                "${_dxc_root}/lib/@lib_name@"
-      IMPORTED_SONAME_RELEASE              "@lib_name@"
-      IMPORTED_SONAME_DEBUG                "@lib_name@"
-      INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
-      IMPORTED_CONFIGURATIONS              "Debug;Release"
-      IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
+add_library(Microsoft::DXIL SHARED IMPORTED)
+set_target_properties(Microsoft::DXIL PROPERTIES
+   IMPORTED_LOCATION                    "${_dxc_root}/@dll_dir@/@dll_name_dxil@"
+   IMPORTED_IMPLIB                      "${_dxc_root}/lib/@lib_name@"
+   IMPORTED_SONAME                      "@lib_name@"
+   INTERFACE_INCLUDE_DIRECTORIES        "${_dxc_root}/include/directx-dxc"
+   IMPORTED_LINK_INTERFACE_LANGUAGES    "C")
 
-   target_link_libraries(Microsoft::DirectXShaderCompiler INTERFACE Microsoft::DXIL)
-
-   set(directx-dxc_FOUND TRUE)
-   set(DIRECTX_DXC_TOOL ${_dxc_exe})
-
-else()
-
-    set(directx-dxc_FOUND FALSE)
-
-endif()
-
-unset(_dxc_exe)
 unset(_dxc_root)

--- a/ports/directx-dxc/portfile.cmake
+++ b/ports/directx-dxc/portfile.cmake
@@ -56,13 +56,13 @@ if (VCPKG_TARGET_IS_LINUX)
 
   file(INSTALL
     "${PACKAGE_PATH}/bin/dxc"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/")
 
   set(dll_name_dxc "libdxcompiler.so")
   set(dll_name_dxil "libdxil.so")
   set(dll_dir  "lib")
   set(lib_name "libdxcompiler.so")
-  set(tool_path "bin/dxc")
+  set(tool_path "tools/${PORT}/dxc")
 else()
   # VCPKG_TARGET_IS_WINDOWS
   if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
@@ -109,7 +109,7 @@ else()
   set(dll_name_dxil "dxil.dll")
   set(dll_dir  "bin")
   set(lib_name "dxcompiler.lib")
-  set(tool_path "tools/directx-dxc/dxc.exe")
+  set(tool_path "tools/${PORT}/dxc.exe")
 endif()
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/directx-dxc-config.cmake.in"

--- a/ports/directx-dxc/portfile.cmake
+++ b/ports/directx-dxc/portfile.cmake
@@ -108,6 +108,8 @@ else()
   set(tool_path "tools/${PORT}/dxc.exe")
 endif()
 
+vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+
 configure_file("${CMAKE_CURRENT_LIST_DIR}/directx-dxc-config.cmake.in"
   "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake"
   @ONLY)

--- a/ports/directx-dxc/portfile.cmake
+++ b/ports/directx-dxc/portfile.cmake
@@ -1,11 +1,7 @@
-set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
-
 set(DIRECTX_DXC_TAG v1.8.2403)
 set(DIRECTX_DXC_VERSION 2024_03_07)
 
-if (NOT VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-   message(STATUS "Note: ${PORT} always requires dynamic library linkage at runtime.")
-endif()
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 if (VCPKG_TARGET_IS_LINUX)
     vcpkg_download_distfile(ARCHIVE

--- a/ports/directx-dxc/portfile.cmake
+++ b/ports/directx-dxc/portfile.cmake
@@ -116,7 +116,5 @@ configure_file("${CMAKE_CURRENT_LIST_DIR}/directx-dxc-config.cmake.in"
   "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake"
   @ONLY)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 vcpkg_install_copyright(FILE_LIST "${LICENSE_TXT}")

--- a/ports/directx-dxc/vcpkg.json
+++ b/ports/directx-dxc/vcpkg.json
@@ -15,6 +15,10 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
+    },
+    {
+      "name": "zlib",
+      "platform": "!static"
     }
   ]
 }

--- a/versions/d-/directx-dxc.json
+++ b/versions/d-/directx-dxc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bb359aa2753ed65f6158846e29a0b9d127f29a49",
+      "git-tree": "4567b5dacc64424288773483ef92b48a72147f2c",
       "version-date": "2024-03-07",
       "port-version": 1
     },


### PR DESCRIPTION
You may pick parts as you like. I didn't test more than `vcpkg install` for x64-linux and x64-linux-dynamic.

- `debug/include` is never written.
- vcpkg wants to have all tools to be in `tools`, even on linux. [I don't like it, but it is a fact.](https://github.com/microsoft/vcpkg/issues/17607)
- The CMake config may just assumed that everything is installed correctly. Otherwise it is a port bug, not a "package not found".
- The cmake config file uses the package name pattern for case-insensitive matches. CMake will set `<requested-name>_FOUND`. I dropped explicit setting of `directx-dxc_FOUND`.
- Just generic target properties.
- Directly set `DIRECTX_DXC_TOOL` as a cache variable. Doesn't hurt, and user might override it to a host path for cross builds.
- Unchanged: The variable name pattern of `DIRECTX_DXC_TOOL` neither matches the former explicit `directx-dxc_FOUND` nor the general `<requested-name>_FOUND` (unless the user asked for `find_package(DIRECTX_DXC)`).
- On linux, the libs use `libz.so.1`. With port `zlib` installed, this will resolve to that port's binary instead of a system binary. To avoid subtle effects from installation order, I suggest to make zlib an explicit dependency at least for dynamic triplets.
